### PR TITLE
Bump gulp-eslint Minimum Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-buffer": "0.0.2",
     "gulp-concat": "^2.3.4",
     "gulp-cssmin": "^0.1.6",
-    "gulp-eslint": "^0.1.8",
+    "gulp-eslint": "^4.0.0",
     "gulp-htmlmin": "^0.1.3",
     "gulp-if": "^1.2.4",
     "gulp-less": "^1.3.5",


### PR DESCRIPTION
**Issue**: https://github.com/ooflorent/js13k-boilerplate/issues/4

#### Justification
When setting up the boilerplate, the current build will error when running any of the custom gulp commands from the command line.

![](https://dl.dropboxusercontent.com/s/avc14mq3c1pwah9/gulp-build-error.png)

#### Changes
1. Bump the `gulp-eslint` version from `^0.1.8` to `4.0.0`

#### Demo
![](https://dl.dropboxusercontent.com/s/wcicl6weifrzesi/gulp-build-fix.png)